### PR TITLE
fix: resize bug - revert sizeMoveWindow to v2.3

### DIFF
--- a/QGoodWindow/QGoodWindow/src/qgoodwindow.cpp
+++ b/QGoodWindow/QGoodWindow/src/qgoodwindow.cpp
@@ -3140,10 +3140,7 @@ void QGoodWindow::sizeMoveWindow()
 
     moveShadow();
 
-    QTimer::singleShot(0, this, [=]{
-        m_main_window->resize(size());
-        m_main_window->repaint();
-    });
+    m_main_window->setGeometry(rect());
 }
 
 void QGoodWindow::setWindowMask()


### PR DESCRIPTION
Fixes: #38 
It seems that using m_main_window->setGeometry(rect()); works better than the QTimer approach. I'm not sure why...
