### PR TITLE
Replace Qt keywords with `Q_*` macros

### DIFF
--- a/QGoodWindow/Examples/GoodPlayground/mainwindow.h
+++ b/QGoodWindow/Examples/GoodPlayground/mainwindow.h
@@ -35,10 +35,10 @@ public:
     MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
 
-public slots:
+public Q_SLOTS:
     void show();
 
-private slots:
+private Q_SLOTS:
     void adjustSizeLabel();
 
 private:

--- a/QGoodWindow/Examples/GoodShowCase/mainwindow.h
+++ b/QGoodWindow/Examples/GoodShowCase/mainwindow.h
@@ -57,7 +57,7 @@ public:
     explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
 
-private slots:
+private Q_SLOTS:
     void themeChange();
 
 private:

--- a/QGoodWindow/Examples/GoodShowCaseGL/glwidget.h
+++ b/QGoodWindow/Examples/GoodShowCaseGL/glwidget.h
@@ -58,7 +58,7 @@ public:
     explicit GLWidget(QWidget *parent = nullptr);
     ~GLWidget();
 
-public slots:
+public Q_SLOTS:
     void rotate();
 
 private:

--- a/QGoodWindow/Examples/GoodShowCaseQML/mainwindow.h
+++ b/QGoodWindow/Examples/GoodShowCaseQML/mainwindow.h
@@ -47,10 +47,10 @@ public:
     explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
 
-public slots:
+public Q_SLOTS:
     QString loadPixmapToString(const QString &path);
 
-private slots:
+private Q_SLOTS:
     QPixmap loadGrayedPixmap(const QPixmap &pix);
     QString loadPixmapAsBase64(const QPixmap &pix);
     void captionButtonStateChangedPrivate(const QGoodWindow::CaptionButtonState &state);

--- a/QGoodWindow/QGoodCentralWidget/QGoodCentralWidget.cmake
+++ b/QGoodWindow/QGoodCentralWidget/QGoodCentralWidget.cmake
@@ -38,11 +38,11 @@ if(qgoodwindow)
         Svg
     )
 
-    target_link_libraries(${PROJECT_NAME} PRIVATE
+    target_link_libraries(${PROJECT_NAME} PUBLIC
         Qt${QT_VERSION_MAJOR}::Svg
     )
 endif()
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE QGOODCENTRALWIDGET)
+target_compile_definitions(${PROJECT_NAME} PUBLIC QGOODCENTRALWIDGET)

--- a/QGoodWindow/QGoodCentralWidget/src/captionbutton.h
+++ b/QGoodWindow/QGoodCentralWidget/src/captionbutton.h
@@ -46,10 +46,10 @@ public:
     explicit CaptionButton(IconType type, QWidget *parent = nullptr);
     ~CaptionButton();
 
-signals:
+Q_SIGNALS:
     void clicked();
 
-public slots:
+public Q_SLOTS:
     void setIconMode(bool icon_dark);
     void setActive(bool is_active);
     void setState(int state);

--- a/QGoodWindow/QGoodCentralWidget/src/iconwidget.h
+++ b/QGoodWindow/QGoodCentralWidget/src/iconwidget.h
@@ -36,7 +36,7 @@ class IconWidget : public QWidget
 public:
     explicit IconWidget(QWidget *parent = nullptr);
 
-public slots:
+public Q_SLOTS:
     void setPixmap(const QPixmap &pixmap);
     void setActive(bool active);
 

--- a/QGoodWindow/QGoodCentralWidget/src/qgoodcentralwidget.h
+++ b/QGoodWindow/QGoodCentralWidget/src/qgoodcentralwidget.h
@@ -54,7 +54,7 @@ public:
                                     QWidget *right_title_bar_widget = nullptr,
                                     bool title_visible = true, bool icon_visible = true);
 
-public slots:
+public Q_SLOTS:
     /** Set the title bar and the central widget unified. */
     void setUnifiedTitleBarAndCentralWidget(bool unified);
 

--- a/QGoodWindow/QGoodCentralWidget/src/titlebar.cpp
+++ b/QGoodWindow/QGoodCentralWidget/src/titlebar.cpp
@@ -552,22 +552,22 @@ void TitleBar::captionButtonStateChanged(const QGoodWindow::CaptionButtonState &
         // Mouse button clicked
     case QGoodWindow::CaptionButtonState::MinimizeClicked:
     {
-        emit m_min_btn->clicked();
+        Q_EMIT m_min_btn->clicked();
 
         break;
     }
     case QGoodWindow::CaptionButtonState::MaximizeClicked:
     {
         if (!m_is_maximized)
-            emit m_max_btn->clicked();
+            Q_EMIT m_max_btn->clicked();
         else
-            emit m_restore_btn->clicked();
+            Q_EMIT m_restore_btn->clicked();
 
         break;
     }
     case QGoodWindow::CaptionButtonState::CloseClicked:
     {
-        emit m_cls_btn->clicked();
+        Q_EMIT m_cls_btn->clicked();
 
         break;
     }

--- a/QGoodWindow/QGoodCentralWidget/src/titlebar.h
+++ b/QGoodWindow/QGoodCentralWidget/src/titlebar.h
@@ -40,13 +40,13 @@ class TitleBar : public QFrame
 public:
     explicit TitleBar(QGoodWindow *gw, QWidget *parent = nullptr);
 
-signals:
+Q_SIGNALS:
     void showMinimized();
     void showNormal();
     void showMaximized();
     void closeWindow();
 
-public slots:
+public Q_SLOTS:
     void setTitle(const QString &title);
     void setIcon(const QPixmap &icon);
     void setActive(bool active);

--- a/QGoodWindow/QGoodCentralWidget/src/titlewidget.cpp
+++ b/QGoodWindow/QGoodCentralWidget/src/titlewidget.cpp
@@ -107,8 +107,7 @@ void TitleWidget::paintEvent(QPaintEvent *event)
     QPainter painter(this);
     painter.setRenderHints(QPainter::Antialiasing);
 
-    QFont font;
-    font.setPixelSize(12);
+    QFont font = this->font();
 #ifdef Q_OS_WIN
     font.setFamily("Segoe UI");
 #else

--- a/QGoodWindow/QGoodCentralWidget/src/titlewidget.h
+++ b/QGoodWindow/QGoodCentralWidget/src/titlewidget.h
@@ -38,7 +38,7 @@ class TitleWidget : public QWidget
 public:
     explicit TitleWidget(TitleBar *title_bar, QWidget *parent = nullptr);
 
-public slots:
+public Q_SLOTS:
     void setText(const QString &text);
     void setActive(bool active);
     void setTitleAlignment(const Qt::Alignment &alignment);

--- a/QGoodWindow/QGoodWindow/QGoodWindow.cmake
+++ b/QGoodWindow/QGoodWindow/QGoodWindow.cmake
@@ -31,11 +31,11 @@ target_sources(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/src/qgoodwindow_style.qrc
 )
 
-target_include_directories(${PROJECT_NAME} PRIVATE
+target_include_directories(${PROJECT_NAME} PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}
 )
 
-target_compile_definitions(${PROJECT_NAME} PRIVATE
+target_compile_definitions(${PROJECT_NAME} PUBLIC
     UNICODE
 )
 
@@ -44,25 +44,25 @@ if(WIN32 AND ${QT_VERSION_MAJOR} EQUAL 5)
         WinExtras
     )
 
-    target_link_libraries(${PROJECT_NAME} PRIVATE
+    target_link_libraries(${PROJECT_NAME} PUBLIC
         Qt5::WinExtras
     )
 endif()
 
 if(${QT_VERSION_MAJOR} EQUAL 5)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE
+    target_compile_definitions(${PROJECT_NAME} PUBLIC
         QT_VERSION_QT5
     )
 endif()
 
 if(${QT_VERSION_MAJOR} EQUAL 6)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE
+    target_compile_definitions(${PROJECT_NAME} PUBLIC
         QT_VERSION_QT6
     )
 endif()
 
 if(WIN32)
-    target_link_libraries(${PROJECT_NAME} PRIVATE
+    target_link_libraries(${PROJECT_NAME} PUBLIC
         Gdi32
         User32
     )
@@ -78,7 +78,7 @@ if(NOT no_qgoodwindow)
             ${CMAKE_CURRENT_LIST_DIR}/src/shadow.cpp ${CMAKE_CURRENT_LIST_DIR}/src/shadow.h
         )
 
-        target_compile_definitions(${PROJECT_NAME} PRIVATE
+        target_compile_definitions(${PROJECT_NAME} PUBLIC
             QGOODWINDOW
         )
 
@@ -88,7 +88,7 @@ if(NOT no_qgoodwindow)
             Widgets
         )
 
-        target_link_libraries(${PROJECT_NAME} PRIVATE
+        target_link_libraries(${PROJECT_NAME} PUBLIC
             Qt${QT_VERSION_MAJOR}::Core
             Qt${QT_VERSION_MAJOR}::Gui
             Qt${QT_VERSION_MAJOR}::Widgets
@@ -103,11 +103,11 @@ if(NOT no_qgoodwindow)
             ${CMAKE_CURRENT_LIST_DIR}/src/shadow.cpp ${CMAKE_CURRENT_LIST_DIR}/src/shadow.h
         )
 
-        target_compile_definitions(${PROJECT_NAME} PRIVATE
+        target_compile_definitions(${PROJECT_NAME} PUBLIC
             QGOODWINDOW
         )
 
-        target_compile_options(${PROJECT_NAME} PRIVATE
+        target_compile_options(${PROJECT_NAME} PUBLIC
             -Wno-deprecated-declarations
         )
 
@@ -115,16 +115,16 @@ if(NOT no_qgoodwindow)
             find_package(PkgConfig REQUIRED)
             pkg_check_modules(GTK2 REQUIRED "gtk+-2.0")
             if(DEFINED GTK2_INCLUDE_DIRS)
-                target_include_directories(${PROJECT_NAME} PRIVATE ${GTK2_INCLUDE_DIRS})
+                target_include_directories(${PROJECT_NAME} PUBLIC ${GTK2_INCLUDE_DIRS})
             endif()
             if(DEFINED GTK2_LIBRARY_DIRS)
-                target_link_directories(${PROJECT_NAME} PRIVATE ${GTK2_LIBRARY_DIRS})
+                target_link_directories(${PROJECT_NAME} PUBLIC ${GTK2_LIBRARY_DIRS})
             endif()
             if(DEFINED GTK2_CFLAGS_OTHER)
-                target_compile_options(${PROJECT_NAME} PRIVATE ${GTK2_CFLAGS_OTHER})
+                target_compile_options(${PROJECT_NAME} PUBLIC ${GTK2_CFLAGS_OTHER})
             endif()
             if(DEFINED GTK2_LIBRARIES)
-                target_link_libraries(${PROJECT_NAME} PRIVATE ${GTK2_LIBRARIES})
+                target_link_libraries(${PROJECT_NAME} PUBLIC ${GTK2_LIBRARIES})
             endif()
         endif()
 
@@ -132,20 +132,20 @@ if(NOT no_qgoodwindow)
             find_package(PkgConfig REQUIRED)
             pkg_check_modules(GTK3 REQUIRED "gtk+-3.0")
             if(DEFINED GTK3_INCLUDE_DIRS)
-                target_include_directories(${PROJECT_NAME} PRIVATE ${GTK3_INCLUDE_DIRS})
+                target_include_directories(${PROJECT_NAME} PUBLIC ${GTK3_INCLUDE_DIRS})
             endif()
             if(DEFINED GTK3_LIBRARY_DIRS)
-                target_link_directories(${PROJECT_NAME} PRIVATE ${GTK3_LIBRARY_DIRS})
+                target_link_directories(${PROJECT_NAME} PUBLIC ${GTK3_LIBRARY_DIRS})
             endif()
             if(DEFINED GTK3_CFLAGS_OTHER)
-                target_compile_options(${PROJECT_NAME} PRIVATE ${GTK3_CFLAGS_OTHER})
+                target_compile_options(${PROJECT_NAME} PUBLIC ${GTK3_CFLAGS_OTHER})
             endif()
             if(DEFINED GTK3_LIBRARIES)
-                target_link_libraries(${PROJECT_NAME} PRIVATE ${GTK3_LIBRARIES})
+                target_link_libraries(${PROJECT_NAME} PUBLIC ${GTK3_LIBRARIES})
             endif()
         endif()
 
-        target_link_libraries(${PROJECT_NAME} PRIVATE
+        target_link_libraries(${PROJECT_NAME} PUBLIC
             X11
         )
 
@@ -156,7 +156,7 @@ if(NOT no_qgoodwindow)
             Test
         )
 
-        target_link_libraries(${PROJECT_NAME} PRIVATE
+        target_link_libraries(${PROJECT_NAME} PUBLIC
             Qt${QT_VERSION_MAJOR}::Core
             Qt${QT_VERSION_MAJOR}::Gui
             Qt${QT_VERSION_MAJOR}::Widgets
@@ -168,13 +168,13 @@ if(NOT no_qgoodwindow)
                 X11Extras
             )
 
-            target_link_libraries(${PROJECT_NAME} PRIVATE
+            target_link_libraries(${PROJECT_NAME} PUBLIC
                 Qt5::X11Extras
             )
         endif()
 
         if(${QT_VERSION_MAJOR} EQUAL 6)
-            target_include_directories(${PROJECT_NAME} PRIVATE
+            target_include_directories(${PROJECT_NAME} PUBLIC
                 ${Qt6Gui_PRIVATE_INCLUDE_DIRS}
             )
         endif()
@@ -189,7 +189,7 @@ if(NOT no_qgoodwindow)
             ${CMAKE_CURRENT_LIST_DIR}/src/qgooddialog.cpp ${CMAKE_CURRENT_LIST_DIR}/src/qgooddialog.h
         )
 
-        target_compile_definitions(${PROJECT_NAME} PRIVATE
+        target_compile_definitions(${PROJECT_NAME} PUBLIC
             QGOODWINDOW
         )
 
@@ -199,13 +199,13 @@ if(NOT no_qgoodwindow)
             Widgets
         )
 
-        target_link_libraries(${PROJECT_NAME} PRIVATE
+        target_link_libraries(${PROJECT_NAME} PUBLIC
             Qt${QT_VERSION_MAJOR}::Core
             Qt${QT_VERSION_MAJOR}::Gui
             Qt${QT_VERSION_MAJOR}::Widgets
         )
 
-        target_link_libraries(${PROJECT_NAME} PRIVATE
+        target_link_libraries(${PROJECT_NAME} PUBLIC
             "-framework AppKit"
             "-framework Cocoa"
             "-framework Foundation"

--- a/QGoodWindow/QGoodWindow/src/qgoodstateholder.cpp
+++ b/QGoodWindow/QGoodWindow/src/qgoodstateholder.cpp
@@ -49,5 +49,5 @@ void QGoodStateHolder::setCurrentThemeDark(bool dark)
 {
 	m_dark = dark;
 
-	emit currentThemeChanged();
+	Q_EMIT currentThemeChanged();
 }

--- a/QGoodWindow/QGoodWindow/src/qgoodstateholder.h
+++ b/QGoodWindow/QGoodWindow/src/qgoodstateholder.h
@@ -42,10 +42,10 @@ private:
     explicit QGoodStateHolder();
     ~QGoodStateHolder();
 
-signals:
+Q_SIGNALS:
     void currentThemeChanged();
 
-public slots:
+public Q_SLOTS:
     bool isCurrentThemeDark() const;
     void setCurrentThemeDark(bool dark);
 

--- a/QGoodWindow/QGoodWindow/src/qgoodwindow.cpp
+++ b/QGoodWindow/QGoodWindow/src/qgoodwindow.cpp
@@ -492,13 +492,13 @@ QGoodWindow::QGoodWindow(QWidget *parent, const QColor &clear_color) : QMainWind
         if (windowTitle().isEmpty())
         {
             setWindowTitle(qApp->applicationName());
-            QTimer::singleShot(0, this, [=]{emit windowTitleChanged(windowTitle());});
+            QTimer::singleShot(0, this, [=]{Q_EMIT windowTitleChanged(windowTitle());});
         }
 
         if (windowIcon().isNull())
         {
             setWindowIcon(qApp->style()->standardIcon(QStyle::SP_DesktopIcon));
-            QTimer::singleShot(0, this, [=]{emit windowIconChanged(windowIcon());});
+            QTimer::singleShot(0, this, [=]{Q_EMIT windowIconChanged(windowIcon());});
         }
     };
 #ifdef Q_OS_WIN
@@ -544,7 +544,7 @@ void QGoodWindow::themeChanged()
     if (m_dark != dark)
     {
         m_dark = dark;
-        emit systemThemeChanged();
+        Q_EMIT systemThemeChanged();
     }
 #endif
 }
@@ -3022,12 +3022,12 @@ LRESULT QGoodWindow::WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lPar
 #endif
     case WM_SETTEXT:
     {
-        emit gw->windowTitleChanged(gw->windowTitle());
+        Q_EMIT gw->windowTitleChanged(gw->windowTitle());
         break;
     }
     case WM_SETICON:
     {
-        emit gw->windowIconChanged(gw->windowIcon());
+        Q_EMIT gw->windowIconChanged(gw->windowIcon());
         break;
     }
     case WM_ENTERSIZEMOVE:
@@ -4126,19 +4126,19 @@ void QGoodWindow::buttonEnter(qintptr button)
     {
     case HTMINBUTTON:
     {
-        emit captionButtonStateChanged(CaptionButtonState::MinimizeHoverEnter);
+        Q_EMIT captionButtonStateChanged(CaptionButtonState::MinimizeHoverEnter);
 
         break;
     }
     case HTMAXBUTTON:
     {
-        emit captionButtonStateChanged(CaptionButtonState::MaximizeHoverEnter);
+        Q_EMIT captionButtonStateChanged(CaptionButtonState::MaximizeHoverEnter);
 
         break;
     }
     case HTCLOSE:
     {
-        emit captionButtonStateChanged(CaptionButtonState::CloseHoverEnter);
+        Q_EMIT captionButtonStateChanged(CaptionButtonState::CloseHoverEnter);
 
         break;
     }
@@ -4161,19 +4161,19 @@ void QGoodWindow::buttonLeave(qintptr button)
     {
     case HTMINBUTTON:
     {
-        emit captionButtonStateChanged(CaptionButtonState::MinimizeHoverLeave);
+        Q_EMIT captionButtonStateChanged(CaptionButtonState::MinimizeHoverLeave);
 
         break;
     }
     case HTMAXBUTTON:
     {
-        emit captionButtonStateChanged(CaptionButtonState::MaximizeHoverLeave);
+        Q_EMIT captionButtonStateChanged(CaptionButtonState::MaximizeHoverLeave);
 
         break;
     }
     case HTCLOSE:
     {
-        emit captionButtonStateChanged(CaptionButtonState::CloseHoverLeave);
+        Q_EMIT captionButtonStateChanged(CaptionButtonState::CloseHoverLeave);
 
         break;
     }
@@ -4194,7 +4194,7 @@ bool QGoodWindow::buttonPress(qintptr button)
         m_is_caption_button_pressed = true;
         m_caption_button_pressed = HTMINBUTTON;
 
-        emit captionButtonStateChanged(CaptionButtonState::MinimizePress);
+        Q_EMIT captionButtonStateChanged(CaptionButtonState::MinimizePress);
 
         activateWindow();
 
@@ -4205,7 +4205,7 @@ bool QGoodWindow::buttonPress(qintptr button)
         m_is_caption_button_pressed = true;
         m_caption_button_pressed = HTMAXBUTTON;
 
-        emit captionButtonStateChanged(CaptionButtonState::MaximizePress);
+        Q_EMIT captionButtonStateChanged(CaptionButtonState::MaximizePress);
 
         activateWindow();
 
@@ -4216,7 +4216,7 @@ bool QGoodWindow::buttonPress(qintptr button)
         m_is_caption_button_pressed = true;
         m_caption_button_pressed = HTCLOSE;
 
-        emit captionButtonStateChanged(CaptionButtonState::ClosePress);
+        Q_EMIT captionButtonStateChanged(CaptionButtonState::ClosePress);
 
         activateWindow();
 
@@ -4247,11 +4247,11 @@ bool QGoodWindow::buttonRelease(qintptr button, bool valid_click)
     {
     case HTMINBUTTON:
     {
-        emit captionButtonStateChanged(CaptionButtonState::MinimizeRelease);
+        Q_EMIT captionButtonStateChanged(CaptionButtonState::MinimizeRelease);
 
         if (valid_click)
         {
-            emit captionButtonStateChanged(CaptionButtonState::MinimizeClicked);
+            Q_EMIT captionButtonStateChanged(CaptionButtonState::MinimizeClicked);
             m_hover_timer->start();
         }
 
@@ -4259,11 +4259,11 @@ bool QGoodWindow::buttonRelease(qintptr button, bool valid_click)
     }
     case HTMAXBUTTON:
     {
-        emit captionButtonStateChanged(CaptionButtonState::MaximizeRelease);
+        Q_EMIT captionButtonStateChanged(CaptionButtonState::MaximizeRelease);
 
         if (valid_click)
         {
-            emit captionButtonStateChanged(CaptionButtonState::MaximizeClicked);
+            Q_EMIT captionButtonStateChanged(CaptionButtonState::MaximizeClicked);
             m_hover_timer->start();
         }
 
@@ -4271,11 +4271,11 @@ bool QGoodWindow::buttonRelease(qintptr button, bool valid_click)
     }
     case HTCLOSE:
     {
-        emit captionButtonStateChanged(CaptionButtonState::CloseRelease);
+        Q_EMIT captionButtonStateChanged(CaptionButtonState::CloseRelease);
 
         if (valid_click)
         {
-            emit captionButtonStateChanged(CaptionButtonState::CloseClicked);
+            Q_EMIT captionButtonStateChanged(CaptionButtonState::CloseClicked);
             m_hover_timer->start();
         }
 

--- a/QGoodWindow/QGoodWindow/src/qgoodwindow.h
+++ b/QGoodWindow/QGoodWindow/src/qgoodwindow.h
@@ -164,7 +164,7 @@ public:
     static QGoodStateHolder *qGoodStateHolderInstance();
 
     /*** QGOODWINDOW FUNCTIONS END ***/
-signals:
+Q_SIGNALS:
     /** On handled caption buttons, this SIGNAL report the state of these buttons. */
     void captionButtonStateChanged(const QGoodWindow::CaptionButtonState &state);
 
@@ -238,7 +238,7 @@ public:
     Q_DECL_DEPRECATED QRect rightCaptionButtonsRect() const
     {Q_ASSERT(false); return QRect();}
 
-public slots:
+public Q_SLOTS:
     /** Set title bar height for *QGoodWindow*. */
     void setTitleBarHeight(int height);
 

--- a/QGoodWindow/QGoodWindow/src/shadow.h
+++ b/QGoodWindow/QGoodWindow/src/shadow.h
@@ -43,7 +43,7 @@ public:
     explicit Shadow(qintptr hwnd, QGoodWindow *gw, QWidget *parent);
 #endif
 
-public slots:
+public Q_SLOTS:
     void showLater();
     void show();
     void hide();

--- a/QGoodWindow/build-library/CMakeLists.txt
+++ b/QGoodWindow/build-library/CMakeLists.txt
@@ -59,6 +59,8 @@ else()
     add_library(${PROJECT_NAME} STATIC)
 endif()
 
+target_compile_definitions(${PROJECT_NAME} PRIVATE QT_NO_KEYWORDS)
+
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Set build mode")
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Release MinSizeRel RelWithDebInfo Debug)
 

--- a/QGoodWindow/build-library/build-qgoodwindow-and-central-widget-shared-lib.pro
+++ b/QGoodWindow/build-library/build-qgoodwindow-and-central-widget-shared-lib.pro
@@ -22,7 +22,7 @@
 
 TEMPLATE = lib
 
-CONFIG += plugin
+CONFIG += plugin no_keywords
 
 TARGET = QGoodWindow
 

--- a/QGoodWindow/build-library/build-qgoodwindow-and-central-widget-static-lib.pro
+++ b/QGoodWindow/build-library/build-qgoodwindow-and-central-widget-static-lib.pro
@@ -22,7 +22,7 @@
 
 TEMPLATE = lib
 
-CONFIG += staticlib
+CONFIG += staticlib no_keywords
 
 TARGET = QGoodWindow
 

--- a/QGoodWindow/build-library/build-qgoodwindow-static-lib.pro
+++ b/QGoodWindow/build-library/build-qgoodwindow-static-lib.pro
@@ -22,7 +22,7 @@
 
 TEMPLATE = lib
 
-CONFIG += staticlib
+CONFIG += staticlib no_keywords
 
 TARGET = QGoodWindow
 

--- a/QGoodWindow/build-library/builld-qgoodwindow-shared-lib.pro
+++ b/QGoodWindow/build-library/builld-qgoodwindow-shared-lib.pro
@@ -22,7 +22,7 @@
 
 TEMPLATE = lib
 
-CONFIG += plugin
+CONFIG += plugin no_keywords
 
 TARGET = QGoodWindow
 


### PR DESCRIPTION
Since the words `signals`, `slots` and `emit` are some common names. They have potential name collisions when mix Qt code with other libraries. This problem has been reported many times:

- https://stackoverflow.com/questions/22188432/qt-macro-keywords-cause-name-collisions
- https://stackoverflow.com/questions/16638077/qt-name-collision-but-no-keywords-not-an-option
- https://stackoverflow.com/questions/37788273/c-qt-variable-named-slots-in-included-external-library

As to myself, I encountered this problem when using OpenCV, a well-known computer vision library before.

So it is recommended to disable them in new projects: https://doc.qt.io/qt-5/signalsandslots.html#using-qt-with-3rd-party-signals-and-slots .